### PR TITLE
Insert `void`

### DIFF
--- a/src/rvc_shared.h
+++ b/src/rvc_shared.h
@@ -78,7 +78,7 @@ int rvc_get_status(const char *name, int json_format, char **conn_status);
  * @return 0 If success, otherwise non-zero will be returned.
  */
 
-int rvc_reload();
+int rvc_reload(void);
 
 /** Import OpenVPN or TunnelBlick VPN profile
  *


### PR DESCRIPTION
Hi, Jin, 

A little style update. Fixes "This function declaration is not a prototype" warning.

![screen shot 2017-09-17 at 00 22 07](https://user-images.githubusercontent.com/193307/30516402-a6f155f4-9b3e-11e7-9f0c-bcf66f0067a4.png)
